### PR TITLE
strWithObj support added.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,11 @@ module.exports = function (opts) {
 
   return es.map(function (file, cb) {
     try {
-      file.contents = new Buffer(frep.strWithArr(String(file.contents), opts));
+      if (Array.isArray(opts)) {
+        file.contents = new Buffer(frep.strWithArr(String(file.contents), opts));
+      } else {
+        file.contents = new Buffer(frep.strWithObj(String(file.contents), opts));
+      }
     } catch (err) {
       console.warn('Error caught from frep: ' + err.message + '.');
     }

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,10 @@ var opts = {
       replacement: ''
     }
   ],
+  patterns_as_object: {
+    'banner': '',
+    'container': ''
+  },
   strip: [
     {
       pattern: /(<([^>]+)>)/ig,
@@ -59,6 +63,16 @@ describe('find and replace HTML', function () {
         .pipe(frep(opts.patterns))
         .pipe(es.map(function (file) {
           var expected = findReplace.strWithArr(read(filename), opts.patterns);
+          expect(String(file.contents)).to.equal(expected);
+          done();
+        }));
+    });
+    it('should replace strings with object replacement patterns', function (done) {
+      var filename = path.join(__dirname, './fixtures/index.html');
+      gulp.src(filename)
+        .pipe(frep(opts.patterns_as_object))
+        .pipe(es.map(function (file) {
+          var expected = findReplace.strWithObj(read(filename), opts.patterns_as_object);
           expect(String(file.contents)).to.equal(expected);
           done();
         }));


### PR DESCRIPTION
Added support for key:value objects as replacement rules.

Example:

```
var replacements = {
  'A': 'AAA',
  'B': 'BBB'
};
```
